### PR TITLE
Only load the helpers file when it's running from the CLI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,7 @@
         "php": "^7.1.3"
     },
     "autoload": {
-        "files": [
-            "src/Illuminate/Foundation/helpers.php"
-        ],
+        "files": [],
         "psr-4": {
             "Illuminate\\": "src/Illuminate/"
         }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,5 +1,9 @@
 <?php
 
+if (php_sapi_name() !== 'cli') {
+    return;
+}
+
 use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\HtmlString;


### PR DESCRIPTION
I'm not sure if you'd except this as it skews from the foundation.

However as zero is a CLI application this might make sense.

We've basically got a problem with the laravel-zero/foundation helpers file high-jacking the website functions.

e.g. it loads before our application, registering an assortment of functions such as `__()` `config()` etc - as these load first, it breaks the website.

Ideally either zero should only include this file when it starts to run or potentially accept the proposed solution to make sure it only defines the functions when its on the CLI.

Hopefully this is something you can consider, as it will make our lives much easier! Without it we'll have to abandon using the zero integration we want as the websites are legacy and cannot have all this changed.

many thanks :)