### PR TITLE
Fix dotenv not working

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -25,7 +25,7 @@ class LoadEnvironmentVariables
         $this->checkForSpecificEnvironmentFile($app);
 
         try {
-            (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
+        	(\Dotenv\Dotenv::create($app->environmentPath(), $app->environmentFile()))->load();
         } catch (InvalidPathException $e) {
             //
         } catch (InvalidFileException $e) {


### PR DESCRIPTION
If using 
```
$app->useEnvironmentPath($path);
$app->loadEnvironmentFrom('warden.conf');
```
Laravel Zero would fail to initialize with the error `Argument 1 passed to Dotenv\Dotenv::__construct() must be an instance of Dotenv\Loader, string given`

This commit solves that