### PR TITLE
Update README and LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Nuno Maduro <enunomaduro@gmail.com>
+Copyright (c) 2017-2019 Nuno Maduro <enunomaduro@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-## About Laravel Zero Foundation
+## Laravel Zero Foundation
 
-This is a mirror from https://github.com/laravel/framework/tree/5.8/src/Illuminate/Foundation
+This is a mirror of `src/Illuminate/Foundation` from [Laravel Framework](https://github.com/laravel/framework).
 
 ## Notes
 
-In this package the class `src/Illuminate/Foundation/Application` doesn't implement Symfonys `HttpKernelInterface`.
+In this package, `Illuminate\Foundation\Application` class doesn't implement `Symfony\Component\HttpKernel\HttpKernelInterface` interface.
 
 ## Support the development
 **Do you like this project? Support it by donating**
@@ -14,4 +14,4 @@ In this package the class `src/Illuminate/Foundation/Application` doesn't implem
 
 ## License
 
-Laravel Zero Foundation is an open-sourced software licensed under the [MIT license](LICENSE.md).
+Laravel Zero Foundation is open-sourced software licensed under the [MIT license](LICENSE.md).


### PR DESCRIPTION
I just do some small things:
- The license year is 2017-2019.
- With the message "This is a mirror of src/Illuminate/Foundation from Laravel Framework.", you needn't to change the version anymore.
- Using class/trait/interface full name (including namespace) is better than using directory.
- Fix the typo "Laravel Zero Foundation is open-sourced software". ("software" is uncountable)

You should update the repository description too. Now, it is "This is a mirror from https://github.com/laravel/framework/tree/5.7/src/Illuminate/Foundation"
