### PR TITLE
Fix usage of 'realpath' function in Console\Kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a mirror of `src/Illuminate/Foundation` from [Laravel Framework](https:/
 
 In this package, `Illuminate\Foundation\Application` class doesn't implement `Symfony\Component\HttpKernel\HttpKernelInterface` interface.
 
+Also in this package, the `Console\Kernel::load()` method does not use the canonicalized absolute path to the `app` directory.
+
 ## Support the development
 **Do you like this project? Support it by donating**
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -233,7 +233,7 @@ class Kernel implements KernelContract
             $command = $namespace.str_replace(
                 ['/', '.php'],
                 ['\\', ''],
-                Str::after($command->getPathname(), realpath(app_path()).DIRECTORY_SEPARATOR)
+                Str::after($command->getPathname(), app_path().DIRECTORY_SEPARATOR)
             );
 
             if (is_subclass_of($command, Command::class) &&


### PR DESCRIPTION
> Opening this as a draft PR for testing later.

<details>
<summary>Composer Test Usage</summary>

```diff
diff --git a/composer.json b/composer.json
index 2ee939c..bfc3a76 100644
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel-zero/framework": "^6.0"
+        "laravel-zero/framework": "^6.0",
+        "laravel-zero/foundation": "dev-bugfix/command-discovery as 6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
@@ -45,5 +46,6 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "bin": ["application"]
+    "bin": ["application"],
+    "repositories": [{"type": "vcs", "url": "git@github.com:pxgamer/laravel-zero-foundation.git"}]
 }
```

</details>

Fixes https://github.com/laravel-zero/laravel-zero/issues/243