### PR TITLE
Fix undefined constant `MASTER_REQUEST`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a mirror of `src/Illuminate/Foundation` from [Laravel Framework](https:/
 ## Notes
 
 In this package, `Illuminate\Foundation\Application` class doesn't implement `Symfony\Component\HttpKernel\HttpKernelInterface` interface.
+The constant `MASTER_REQUEST` is copied in from `HttpKernelInterface`.
 
 Also in this package, the `Console\Kernel::load()` method does not use the canonicalized absolute path to the `app` directory.
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -35,6 +35,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
     const VERSION = '8.15.0';
 
     /**
+     * Copied from HttpKernelInterface, which this class no longer extends.
+     */
+    const MASTER_REQUEST = 1;
+
+    /**
      * The base path for the Laravel installation.
      *
      * @var string


### PR DESCRIPTION
`MASTER_REQUEST` is referenced https://github.com/laravel-zero/foundation/blob/v8.15.0/src/Illuminate/Foundation/Application.php#L916 , but never defined due to not implementing `HttpKernelInterface`.