### PR TITLE
fix: guard FormRequest::flushState() for console-only installs

### DIFF
--- a/bin/sync
+++ b/bin/sync
@@ -64,6 +64,9 @@ transform([
     line('Factory::flushState();', 2) => PHP_EOL.line('if (class_exists(Factory::class)) {
             Factory::flushState();
         }'.PHP_EOL, 2),
+    line('FormRequest::flushState();', 2) => PHP_EOL.line('// `FormRequest` extends `Illuminate\Http\Request`, so `class_exists()` must check the parent:', 2).line('if (class_exists(\Illuminate\Http\Request::class)) {
+            FormRequest::flushState();
+        }'.PHP_EOL, 2),
     line('HandleCors::flushState();', 2) => PHP_EOL.line('if (class_exists(HandleCors::class)) {
             HandleCors::flushState();
         }'.PHP_EOL, 2),

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php
@@ -189,7 +189,12 @@ trait InteractsWithTestCaseLifecycle
             Factory::flushState();
         }
 
-        FormRequest::flushState();
+
+        // `FormRequest` extends `Illuminate\Http\Request`, so `class_exists()` must check the parent:
+        if (class_exists(\Illuminate\Http\Request::class)) {
+            FormRequest::flushState();
+        }
+
         EncodedHtmlString::flushState();
 
         if (class_exists(EncryptCookies::class)) {


### PR DESCRIPTION
## The problem

On `feature/13.x-upgrade`, every test that tears down through the Foundation test case fails in a console-only application:

```
Class "Illuminate\Http\Request" not found
at src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php:192
```

`FormRequest::flushState()` is new to Laravel 13's teardown list (it isn't present on `main`/`12.x`, which is why this only shows up here). `bin/sync` guards the other optional-component flushes — `Factory`, `EncryptCookies`, `HandleCors`, `Markdown`, `Queue`, `Validator`, … — but `FormRequest` slipped through. `Illuminate\Foundation\Http\FormRequest` extends `Illuminate\Http\Request`, and `illuminate/http` isn't installed in a Laravel Zero app.

This is what currently reddens CI on `laravel-zero/laravel-zero@feature/13.x-upgrade` — the `inspire` command test passes its assertion and then dies in teardown.

## The fix

Add the missing transform to `bin/sync`, guarding on **the parent class**:

```php
if (class_exists(\Illuminate\Http\Request::class)) {
    FormRequest::flushState();
}
```

The guard deliberately doesn't follow the `class_exists(X::class)` shape of its neighbours. `class_exists(FormRequest::class)` autoloads `FormRequest`, and PHP fatals on the missing parent while doing so — before `class_exists()` ever gets to return `false`:

```
THREW: Error: Class "Illuminate\Http\Request" not found
```

Hence the inline comment in the generated file, so it doesn't get "corrected" back to `FormRequest::class` later.

## Verification

- Ran `composer sync` against `laravel/framework:v13.14.0` (the version this branch was last synced at). The only file that changes is `InteractsWithTestCaseLifecycle.php` — everything else regenerates byte-for-byte, so the committed `src/` and `bin/sync` stay in agreement.
- Dropped the regenerated file into a `laravel-zero/laravel-zero` install running the 13.x branches: `2 passed`, previously `1 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)